### PR TITLE
Implement Jacoco Test Coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>1.5.8</version>
@@ -101,9 +105,50 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <!-- Jacoco plugin -->
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>coverage-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>coverage-report</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- Threshold -->
+                    <execution>
+                        <id>coverage-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <excludes>
+                                        <exclude>com.asimio.demo.Application</exclude>
+                                    </excludes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>80%</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This pull request adds Jacoco Test Coverage for the application to provide coverage reports for all the built classes.

In order to obtain the coverage report, the following maven commands should be run to generate the various coverage reports.

1. `./mvnw clean test` 
2. `./mvnw jacoco:report` 

to generate a coverage report similar to this one shown below.

<img width="1437" alt="Screenshot 2020-02-19 at 13 25 55" src="https://user-images.githubusercontent.com/30991429/74825731-775c9500-531b-11ea-83f5-8a973ba7b738.png">

<img width="1440" alt="Screenshot 2020-02-19 at 13 26 04" src="https://user-images.githubusercontent.com/30991429/74825826-9e1acb80-531b-11ea-9fae-9741e1303c47.png">


<img width="1438" alt="Screenshot 2020-02-19 at 13 26 15" src="https://user-images.githubusercontent.com/30991429/74825843-a6730680-531b-11ea-92ac-907eebd6226b.png">

